### PR TITLE
Fix event section grid layout

### DIFF
--- a/client/styles/EventDrawer.module.css
+++ b/client/styles/EventDrawer.module.css
@@ -95,6 +95,7 @@
 
 .drawer[data-active=true] {
     position: relative;
+    z-index: 1;
     display: block;
 
     opacity: 1;
@@ -104,6 +105,7 @@
 
 .drawer[data-active=false] {
     position: absolute;
+    z-index: 1;
     transition: all 400ms;
     opacity: 0;
     filter: blur(5px);
@@ -124,8 +126,10 @@
     }
 
     .drawer > * {
-        flex-direction: row;
-        align-items: flex-start;
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(600px, 1fr));
+        grid-gap: 30px;
+        justify-items: center;
     }
 
     .holder {


### PR DESCRIPTION
- Previously the event section had a flex layout which led to a scrollable row which left a lot of vertical spaces unused
- Now, most of the spaces would be used to display the event cards